### PR TITLE
样式优化

### DIFF
--- a/css/def.css
+++ b/css/def.css
@@ -1,7 +1,7 @@
 *{
     margin: 0;
     padding: 0;
-    line-height: 1;
+    line-height: normal;
     user-select: none;
     color: inherit;
 }

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         }
         .form{
             margin: auto;
-            width: 85vw;
+            width: 40vw;
         }
         .form label{
             color: #fff;
@@ -27,6 +27,12 @@
             outline: 0;
             border: 0;
             border-radius: 5px;
+        }
+        @media (max-width: 991px) {
+            .form{
+                margin: auto;
+                width: 85vw;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
def.css疑似是reset样式，但单倍行距会导致没有定义行距的文字段落全部挤到一起，这种简单页面可以先去掉行距覆盖避免麻烦。